### PR TITLE
Adds docker image save and load to prestage and install scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,7 @@ docker_remove_if_exists() {
 docker_run_dapr_placement() {
     echo -e "\nLaunching dapr placement service..."
     docker_remove_if_exists dapr_placement
+    docker load -i ${PRESTAGE_DIRECTORY}/dapr_placement.tar
     docker run \
         --name dapr_placement \
         --restart "always" \
@@ -34,6 +35,7 @@ docker_run_dapr_placement() {
 docker_run_redis() {
     echo -e "\nLaunching redis service..."
     docker_remove_if_exists dapr_redis
+    docker load -i ${PRESTAGE_DIRECTORY}/redis.tar
     docker run \
         --name dapr_redis \
         --restart "always" \
@@ -46,6 +48,7 @@ docker_run_redis() {
 docker_run_zipkin() {
     echo -e "\nLaunching zipkin service..."
     docker_remove_if_exists dapr_zipkin
+    docker load -i ${PRESTAGE_DIRECTORY}/zipkin.tar
     docker run \
         --name dapr_zipkin \
         --restart "always" \

--- a/prestage.sh
+++ b/prestage.sh
@@ -56,10 +56,13 @@ prepare_prestaged_directory() {
 prestage_docker_images() {
     echo ""
     docker pull daprio/dapr:${DAPR_VERSION}
+    docker save daprio/dapr:${DAPR_VERSION} -o ${PRESTAGE_DIRECTORY}/dapr_placement.tar
     echo ""
     docker pull redis:latest
+    docker save redis:latest -o ${PRESTAGE_DIRECTORY}/redis.tar
     echo ""
     docker pull openzipkin/zipkin:latest
+    docker save openzipkin/zipkin:latest -o ${PRESTAGE_DIRECTORY}/zipkin.tar
 }
 
 


### PR DESCRIPTION
With this PR, prestage.sh will now save docker images required by dapr to the prestaged directory via **docker save**. install.sh likewise loads these images via **docker load** when launching the dapr docker containers.

Previously if these images were not already present on host, they would be pulled down over the internet.